### PR TITLE
Use node:10-alpine instead of kth-nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kthse/kth-nodejs:9.11.0
+FROM node:10.12-alpine
 RUN apk update; apk add python make;
 COPY ["package.json", "package.json"]
 COPY ["package-lock.json", "package-lock.json"]


### PR DESCRIPTION
(Note: I have this PR to have an open discussion)

---

## KTH Node.js or official Node.js?

Right now, we are using a Node.js version that we have made ourselves based on Linux Alpine, one that we called `kth-nodejs`. However, in Docker Hub, there is already an Node.js version based on Linux Alpine.

I want to know what are the **reasons** behind using the KTH one in favour of the official one.

<details>
<summary>BTW, we need to update NodeJS from 9 to 10 anyways but that is not the discussion</summary>

## We need to update Node.js from 9 to 10 because Node.js 9 is unsupported now.

Actually, all non-even versions (7, 9, 11, etc.) get "unsupported" once the following LTS is released.

- For example, when 10 is released, 9 becomes unsupported, but 8 is still supported because is a LTS version.
</details>