### PR TITLE
Setting/updating ladok uid when creating/updating users.

### DIFF
--- a/test/integration/user.test.js
+++ b/test/integration/user.test.js
@@ -15,7 +15,8 @@ test('should create a new user in canvas', t => {
     username,
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
-    'primary_email': 'esandin@gmail.com' }
+    'primary_email': 'esandin@gmail.com',
+    'ladok3_student_uid': `${kthid}-ladok` }
 
   handleMessages(message)
     .then(() => canvasApi.getUser(kthid))
@@ -34,7 +35,8 @@ test('should create a new user of affiliation:member in canvas', t => {
     username,
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
-    'primary_email': 'esandin@gmail.com' }
+    'primary_email': 'esandin@gmail.com',
+    'ladok3_student_uid': `${kthid}-ladok` }
 
   handleMessages(message)
     .then(() => canvasApi.getUser(kthid))
@@ -53,7 +55,8 @@ test('should update a user in canvas', t => {
     username,
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
-    'primary_email': 'esandin@gmail.com' }
+    'primary_email': 'esandin@gmail.com',
+    'ladok3_student_uid': `${kthid}-ladok` }
 
   const message2 = {
     kthid,
@@ -63,7 +66,8 @@ test('should update a user in canvas', t => {
     username,
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg Uppdaterad',
-    'primary_email': 'esandin@gmail.com' }
+    'primary_email': 'esandin@gmail.com',
+    'ladok3_student_uid': `${kthid}-ladok` }
 
   handleMessages(message, message2)
     .then(() => canvasApi.getUser(kthid))

--- a/test/integration/user.test.js
+++ b/test/integration/user.test.js
@@ -25,6 +25,26 @@ test('should create a new user in canvas', t => {
     .then(user => t.ok(user))
 })
 
+test('should create a new user in canvas even without ladokId', t => {
+  t.plan(1)
+  const kthid = randomstring.generate(8)
+  const ladokId = randomstring.generate(24)
+  const message = {
+    kthid,
+    'ugClass': 'user',
+    'deleted': false,
+    'affiliation': ['student'],
+    username,
+    'family_name': 'Stenberg',
+    'given_name': 'Emil Stenberg',
+    'primary_email': 'esandin@gmail.com'
+  }
+
+  handleMessages(message)
+    .then(() => canvasApi.getUser(kthid))
+    .then(user => t.ok(user))
+})
+
 test('should create a new user of affiliation:member in canvas', t => {
   t.plan(1)
   const kthid = randomstring.generate(8)

--- a/test/integration/user.test.js
+++ b/test/integration/user.test.js
@@ -28,7 +28,7 @@ test('should create a new user in canvas', t => {
 test('should create a new user in canvas even without ladokId', t => {
   t.plan(1)
   const kthid = randomstring.generate(8)
-  const ladokId = randomstring.generate(24)
+  const username = `${kthid}_abc`
   const message = {
     kthid,
     'ugClass': 'user',

--- a/test/integration/user.test.js
+++ b/test/integration/user.test.js
@@ -6,6 +6,7 @@ const randomstring = require('randomstring')
 test('should create a new user in canvas', t => {
   t.plan(1)
   const kthid = randomstring.generate(8)
+  const ladokId = randomstring.generate(24)
   const username = `${kthid}_abc`
   const message = {
     kthid,
@@ -16,7 +17,8 @@ test('should create a new user in canvas', t => {
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
     'primary_email': 'esandin@gmail.com',
-    'ladok3_student_uid': `${kthid}-ladok` }
+    'ladok3_student_uid': ladokId
+  }
 
   handleMessages(message)
     .then(() => canvasApi.getUser(kthid))
@@ -27,6 +29,7 @@ test('should create a new user of affiliation:member in canvas', t => {
   t.plan(1)
   const kthid = randomstring.generate(8)
   const username = `${kthid}_abc`
+  const ladokId = randomstring.generate(24)
   const message = {
     kthid,
     'ugClass': 'user',
@@ -36,7 +39,8 @@ test('should create a new user of affiliation:member in canvas', t => {
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
     'primary_email': 'esandin@gmail.com',
-    'ladok3_student_uid': `${kthid}-ladok` }
+    'ladok3_student_uid': ladokId
+  }
 
   handleMessages(message)
     .then(() => canvasApi.getUser(kthid))
@@ -47,6 +51,8 @@ test('should update a user in canvas', t => {
   t.plan(1)
   const kthid = 'emiluppdaterar-namn'
   const username = `${kthid}_abc`
+  const ladokId = randomstring.generate(24)
+
   const message = {
     kthid,
     'ugClass': 'user',
@@ -56,7 +62,8 @@ test('should update a user in canvas', t => {
     'family_name': 'Stenberg',
     'given_name': 'Emil Stenberg',
     'primary_email': 'esandin@gmail.com',
-    'ladok3_student_uid': `${kthid}-ladok` }
+    'ladok3_student_uid': ladokId
+  }
 
   const message2 = {
     kthid,


### PR DESCRIPTION
Decided to follow the old model of having one big object that is used in all requests connected to creating or updating a user. One thing that'd be nice to get some feedback on is whether or not we should have a "hardcoded" value for the account i.e. account 1 - what do you think?

Furthermore, I added a least effort "test" by including the `ladok3_student_uid` in the integration tests concerning creating/updating users, making sure nothing explodes.