### PR TITLE
Fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,9 @@
 FROM kthse/kth-nodejs:10.14.0
+WORKDIR /usr/src/app
 
-RUN apk update; apk add python make;
-WORKDIR /lms-sync-users
-COPY ["package.json", "/lms-sync-users/package.json"]
-COPY ["package-lock.json", "/lms-sync-users/package-lock.json"]
-RUN npm ci --production
+COPY package.json package-lock.json ./
+RUN npm ci --only=production
 
-# Source files in root
-COPY [".env.in", ".env.in"]
-COPY ["app.js", "/lms-sync-users/app.js"]
-COPY ["canvasApi.js", "/lms-sync-users/canvasApi.js"]
-COPY ["csvFile.js", "/lms-sync-users/csvFile.js"]
-
-# Source files directories
-COPY ["config", "/lms-sync-users/config"]
-COPY ["server", "/lms-sync-users/server"]
-COPY ["messages", "/lms-sync-users/messages"]
-
+COPY . .
 EXPOSE 3000
-
 CMD ["node", "app.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             environment {
                 COMPOSE_PROJECT_NAME = "${env.BUILD_TAG}"
 
-                CANVAS_API_KEY = credentials('CANVAS_API_TOKEN_2')
+                CANVAS_API_KEY = credentials('CANVAS_API_TOKEN_1')
                 CANVAS_API_URL = 'https://kth.test.instructure.com/api/v1'
                 AZURE_SHARED_ACCESS_KEY = credentials('AZURE_SHARED_ACCESS_KEY')
                 AZURE_SHARED_ACCESS_KEY_NAME = credentials('AZURE_SHARED_ACCESS_KEY_NAME')

--- a/docker-compose-integration-tests.yml
+++ b/docker-compose-integration-tests.yml
@@ -6,11 +6,11 @@ services:
   integration_tests:
     build: .
     image: $LOCAL_IMAGE_ID
-    volumes:
-      - ./test:/lms-sync-users/test
-      - ./node_modules:/lms-sync-users/node_modules
     tty: true
-    command: npm run test:docker-integration
+    command: >
+      sh -c "apk add openssl &&
+             npm install &&
+             npm test:integration"
     environment:
       - PROXY_PREFIX_PATH
       - CSV_DIR

--- a/docker-compose-integration-tests.yml
+++ b/docker-compose-integration-tests.yml
@@ -9,8 +9,8 @@ services:
     tty: true
     command: >
       sh -c "apk add openssl &&
-             npm install &&
-             npm test:integration"
+             npm ci &&
+             npm run test:integration"
     environment:
       - PROXY_PREFIX_PATH
       - CSV_DIR

--- a/docker-compose-unit-tests.yml
+++ b/docker-compose-unit-tests.yml
@@ -6,11 +6,8 @@ services:
   unit_test:
     build: .
     image: $LOCAL_IMAGE_ID
-
-    volumes:
-      - ./test:/lms-sync-users/test
-      - ./node_modules:/lms-sync-users/node_modules
-      - ./.prettierignore:/lms-sync-users/.prettierignore
-
     tty: true
-    command: npm run test:docker-unit
+    command: >
+      sh -c "apk add openssl &&
+             npm install &&
+             npm test"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "coverage": "cross-env NODE_ENV=development istanbul cover tape -- \"messages/*.js\" -- \"server/**/*.js\" -- \"test/**/*.js\"",
     "format": "prettier-standard \"**/*.{js,md,yml,json}\"",
     "test": "prettier-standard --lint --check \"**/*.{js,md,yml,json}\" && cross-env NODE_ENV=test tape \"test/unit/**/*.js\" | tap-spec",
-    "test:docker-unit": "apk update; apk add python make; npm install --no-optional; npm test",
     "test:docker-integration": "apk update; apk add python make; npm install --no-optional; npm run test:integration",
     "start": "cross-env NODE_ENV=development nodemon app.js",
     "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short",
-    "test-unit-in-docker": "ID=$(docker build -q .) && LOCAL_IMAGE_ID=$ID docker-compose -f docker-compose-unit-tests.yml up --abort-on-container-exit --always-recreate-deps",
     "test-integration-in-docker": "ID=$(docker build -q .) && LOCAL_IMAGE_ID=$ID docker-compose -f docker-compose-integration-tests.yml up --abort-on-container-exit --always-recreate-deps"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
     "coverage": "cross-env NODE_ENV=development istanbul cover tape -- \"messages/*.js\" -- \"server/**/*.js\" -- \"test/**/*.js\"",
     "format": "prettier-standard \"**/*.{js,md,yml,json}\"",
     "test": "prettier-standard --lint --check \"**/*.{js,md,yml,json}\" && cross-env NODE_ENV=test tape \"test/unit/**/*.js\" | tap-spec",
-    "test:docker-integration": "apk update; apk add python make; npm install --no-optional; npm run test:integration",
     "start": "cross-env NODE_ENV=development nodemon app.js",
-    "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short",
-    "test-integration-in-docker": "ID=$(docker build -q .) && LOCAL_IMAGE_ID=$ID docker-compose -f docker-compose-integration-tests.yml up --abort-on-container-exit --always-recreate-deps"
+    "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short"
   },
   "dependencies": {
     "@kth/reqvars": "^2.0.1",


### PR DESCRIPTION
This PR fixes builds in Docker

- Uses a new Canvas token (the current one is outdated)
- Eliminates volumes (volumes break builds as seen in other projects)
- Simplify npm commands for integration tests by putting Docker-related things outside of them