### PR TITLE
Update canvas api

### DIFF
--- a/canvasApi.js
+++ b/canvasApi.js
@@ -1,13 +1,86 @@
 const logger = require('./server/logging')
-const CanvasApi = require('kth-canvas-api')
+const CanvasApi = require('@kth/canvas-api')
 
 logger.info('using canvas api at:', process.env.CANVAS_API_URL)
 
-const canvasApi = new CanvasApi(
+const canvasApi = CanvasApi(
   process.env.CANVAS_API_URL,
   process.env.CANVAS_API_KEY
 )
 
-canvasApi.logger = logger
+module.exports = {
+  async sendCsvFile (fileName, flag) {
+    const {body} = await canvasApi.sendSis('/accounts/1/sis_imports', fileName)
+    return body
+  },
+  async getUser (sisUserId) {
+    const { body } = await canvasApi.get(`/users/sis_user_id:${sisUserId}`)
+    return body
+  },
+  async get (endpoint) {
+    const { body } = await canvasApi.get(endpoint)
+    return body
+  },
+  updateUser (data, id) {
+    return canvasApi.requestUrl(`/users/${id}`, 'PUT', data)
+  },
+  requestCanvas (url, method, body) {
+    return canvasApi.requestUrl(url, method, body)
+  },
+  createUser (data) {
+    return canvasApi.requestUrl('/accounts/1/users', 'POST', data)
+  },
+  async createCourse (data, accountId) {
+    const { body } = await canvasApi.requestUrl(`/accounts/${accountId}/courses`, 'POST', data)
+    return body
+  },
+  createDefaultSection (course) {
+    const courseSection = {
+      course_section: {
+        name: `Section for ${course.name}`,
+        sis_course_id: course.sis_course_id,
+        sis_section_id: course.sis_course_id
+      }
+    }
 
-module.exports = canvasApi
+    return canvasApi.requestUrl(`/courses/${course.id}/sections`, 'POST', courseSection)
+  },
+  async pollUntilSisComplete(sisImportId, wait = 100) {
+    console.log('............', sisImportId)
+    return new Promise((resolve, reject) => {
+      canvasApi.get(`/accounts/1/sis_imports/${sisImportId}`)
+        .then(result => {
+          logger.info('progress:', result.body.progress)
+          if (result.body.progress === 100) {
+          // csv complete
+            resolve(result.body)
+          } else {
+            logger.info(`not yet complete, try again in ${wait / 1000} seconds`)
+            // Not complete, wait and try again
+            setTimeout(() => {
+              return this.pollUntilSisComplete(sisImportId, wait * 2)
+                .then(result => resolve(result))
+            }, wait)
+          }
+        })
+    })
+  },
+
+  async getEnrollments (courseId) {
+    const enrollments = canvasApi.list(`/courses/${courseId}/enrollments`).toArray()
+
+    return enrollments
+  },
+
+  async getSectionEnrollments (courseId, sisSectionId) {
+    console.log('>>>>>', courseId, sisSectionId)
+    const enrollments = await canvasApi.list(
+      `courses/${courseId}/enrollments`,
+      {
+        sis_section_id: sisSectionId
+      }
+    ).toArray()
+
+    return enrollments
+  }
+}

--- a/canvasApi.js
+++ b/canvasApi.js
@@ -10,7 +10,10 @@ const canvasApi = CanvasApi(
 
 module.exports = {
   async sendCsvFile (fileName, flag) {
-    const {body} = await canvasApi.sendSis('/accounts/1/sis_imports', fileName)
+    const { body } = await canvasApi.sendSis(
+      '/accounts/1/sis_imports',
+      fileName
+    )
     return body
   },
   async getUser (sisUserId) {
@@ -31,7 +34,11 @@ module.exports = {
     return canvasApi.requestUrl('/accounts/1/users', 'POST', data)
   },
   async createCourse (data, accountId) {
-    const { body } = await canvasApi.requestUrl(`/accounts/${accountId}/courses`, 'POST', data)
+    const { body } = await canvasApi.requestUrl(
+      `/accounts/${accountId}/courses`,
+      'POST',
+      data
+    )
     return body
   },
   createDefaultSection (course) {
@@ -43,43 +50,48 @@ module.exports = {
       }
     }
 
-    return canvasApi.requestUrl(`/courses/${course.id}/sections`, 'POST', courseSection)
+    return canvasApi.requestUrl(
+      `/courses/${course.id}/sections`,
+      'POST',
+      courseSection
+    )
   },
-  async pollUntilSisComplete(sisImportId, wait = 100) {
+  async pollUntilSisComplete (sisImportId, wait = 100) {
     console.log('............', sisImportId)
     return new Promise((resolve, reject) => {
-      canvasApi.get(`/accounts/1/sis_imports/${sisImportId}`)
-        .then(result => {
-          logger.info('progress:', result.body.progress)
-          if (result.body.progress === 100) {
+      canvasApi.get(`/accounts/1/sis_imports/${sisImportId}`).then(result => {
+        logger.info('progress:', result.body.progress)
+        if (result.body.progress === 100) {
           // csv complete
-            resolve(result.body)
-          } else {
-            logger.info(`not yet complete, try again in ${wait / 1000} seconds`)
-            // Not complete, wait and try again
-            setTimeout(() => {
-              return this.pollUntilSisComplete(sisImportId, wait * 2)
-                .then(result => resolve(result))
-            }, wait)
-          }
-        })
+          resolve(result.body)
+        } else {
+          logger.info(`not yet complete, try again in ${wait / 1000} seconds`)
+          // Not complete, wait and try again
+          setTimeout(() => {
+            return this.pollUntilSisComplete(sisImportId, wait * 2).then(
+              result => resolve(result)
+            )
+          }, wait)
+        }
+      })
     })
   },
 
   async getEnrollments (courseId) {
-    const enrollments = canvasApi.list(`/courses/${courseId}/enrollments`).toArray()
+    const enrollments = canvasApi
+      .list(`/courses/${courseId}/enrollments`)
+      .toArray()
 
     return enrollments
   },
 
   async getSectionEnrollments (courseId, sisSectionId) {
     console.log('>>>>>', courseId, sisSectionId)
-    const enrollments = await canvasApi.list(
-      `courses/${courseId}/enrollments`,
-      {
+    const enrollments = await canvasApi
+      .list(`courses/${courseId}/enrollments`, {
         sis_section_id: sisSectionId
-      }
-    ).toArray()
+      })
+      .toArray()
 
     return enrollments
   }

--- a/canvasApi.js
+++ b/canvasApi.js
@@ -98,9 +98,9 @@ module.exports = {
   // This function is used in `server/systemroutes` (a.k.a. the monitor page)
   async getRootAccount () {
     try {
-      const account = await canvasApi.get('/accounts/1')
+      const { body } = await canvasApi.get('/accounts/1')
 
-      return account.name === 'KTH Royal Institute of Technology'
+      return body.name === 'KTH Royal Institute of Technology'
     } catch (err) {
       logger.error(err, 'Error when getting the root account')
       return false

--- a/canvasApi.js
+++ b/canvasApi.js
@@ -86,7 +86,6 @@ module.exports = {
   },
 
   async getSectionEnrollments (courseId, sisSectionId) {
-    console.log('>>>>>', courseId, sisSectionId)
     const enrollments = await canvasApi
       .list(`courses/${courseId}/enrollments`, {
         sis_section_id: sisSectionId
@@ -94,5 +93,17 @@ module.exports = {
       .toArray()
 
     return enrollments
+  },
+
+  // This function is used in `server/systemroutes` (a.k.a. the monitor page)
+  async getRootAccount () {
+    try {
+      const account = await canvasApi.get('/accounts/1')
+
+      return account.name === 'KTH Royal Institute of Technology'
+    } catch(err) {
+      logger.error(err, 'Error when getting the root account')
+      return false
+    }
   }
 }

--- a/canvasApi.js
+++ b/canvasApi.js
@@ -101,7 +101,7 @@ module.exports = {
       const account = await canvasApi.get('/accounts/1')
 
       return account.name === 'KTH Royal Institute of Technology'
-    } catch(err) {
+    } catch (err) {
       logger.error(err, 'Error when getting the root account')
       return false
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,77 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@kth/canvas-api": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@kth/canvas-api/-/canvas-api-2.1.2.tgz",
+      "integrity": "sha512-3cgJhyu8zKOWwa6FMR0zlh2xg8NYxS3P+vhCge4CQvR21/H5K934rbrlf0hMaB76ARBjSoP9ZKfJ5pubwUd8nA==",
+      "requires": {
+        "@hapi/joi": "^15.1.0",
+        "debug": "^4.1.1",
+        "form-data": "^2.5.0",
+        "got": "^9.6.0",
+        "query-string": "^6.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "@kth/reqvars": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@kth/reqvars/-/reqvars-2.0.1.tgz",
@@ -218,6 +289,7 @@
       "version": "6.9.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
       "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -367,6 +439,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -374,7 +447,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -390,12 +464,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "azure-common": {
       "version": "0.9.22",
@@ -444,6 +520,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -702,7 +779,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -928,7 +1006,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -992,6 +1071,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1015,6 +1095,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -1251,6 +1336,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1587,7 +1673,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -1603,12 +1690,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.1.0",
@@ -1680,7 +1769,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1812,12 +1902,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1875,6 +1967,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1991,12 +2084,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -2067,6 +2162,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -2408,7 +2504,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -2431,7 +2528,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2460,7 +2558,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -2476,12 +2575,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2492,12 +2593,14 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2518,21 +2621,6 @@
       "requires": {
         "json-buffer": "3.0.0"
       }
-    },
-    "kth-canvas-api": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/kth-canvas-api/-/kth-canvas-api-0.15.7.tgz",
-      "integrity": "sha512-nhfh72J7siHE8tex07rHUE+fvE34x/Jsd4Ww0jh9xTK1P1YlD6ynBK85x68/L94Ha7qzC9m0bBaaoQXg0zKKDA==",
-      "requires": {
-        "kth-console-log": "1.x",
-        "request": "^2.88.0",
-        "request-promise": "^4.2.2"
-      }
-    },
-    "kth-console-log": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/kth-console-log/-/kth-console-log-1.2.2.tgz",
-      "integrity": "sha1-vHwdZec4ATXv0+LUfoYDd1nFuQk="
     },
     "kth-node-server": {
       "version": "3.1.2",
@@ -2914,7 +3002,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -3290,7 +3379,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3502,7 +3592,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.1.1",
@@ -3719,7 +3810,8 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.7",
@@ -3739,7 +3831,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "pupa": {
       "version": "2.0.1",
@@ -3753,7 +3846,18 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "randomstring": {
       "version": "1.1.5",
@@ -3874,6 +3978,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3895,25 +4000,6 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      }
-    },
-    "request-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
-      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.3",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
-      "requires": {
-        "lodash": "^4.17.15"
       }
     },
     "resolve": {
@@ -4196,6 +4282,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4206,6 +4297,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4223,10 +4315,10 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.1",
@@ -4660,6 +4752,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -4668,7 +4761,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -4694,6 +4788,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4701,7 +4796,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -4863,6 +4959,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4897,7 +4994,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -4920,6 +5018,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short"
   },
   "dependencies": {
+    "@kth/canvas-api": "^2.1.2",
     "@kth/reqvars": "^2.0.1",
     "bluebird": "^3.7.2",
     "bunyan": "^1.8.13",
     "dotenv": "^6.2.0",
     "express": "^4.17.1",
     "got": "^9.6.0",
-    "kth-canvas-api": "^0.15.6",
     "kth-node-server": "^3.1.2",
     "moment": "^2.27.0",
     "rhea": "^1.0.12",

--- a/test/integration/enrollment.test.js
+++ b/test/integration/enrollment.test.js
@@ -82,10 +82,12 @@ test('should enroll an employee in Miljöutbildningen and Canvas at KTH', async 
   await canvasApi.pollUntilSisComplete(resp.id)
 
   const muEnrollments = await canvasApi.getSectionEnrollments(
-    muId, 'app.katalog3.A.section1'
+    muId,
+    'app.katalog3.A.section1'
   )
   const ckEnrollments = await canvasApi.getSectionEnrollments(
-    ckId, 'app.katalog3.A.section2'
+    ckId,
+    'app.katalog3.A.section2'
   )
 
   t.ok(

--- a/test/integration/enrollment.test.js
+++ b/test/integration/enrollment.test.js
@@ -81,11 +81,11 @@ test('should enroll an employee in Miljöutbildningen and Canvas at KTH', async 
   const [{ resp }] = await handleMessages(message)
   await canvasApi.pollUntilSisComplete(resp.id)
 
-  const muEnrollments = await canvasApi.get(
-    `courses/${muId}/enrollments?sis_section_id[]=app.katalog3.A.section1`
+  const muEnrollments = await canvasApi.getSectionEnrollments(
+    muId, 'app.katalog3.A.section1'
   )
-  const ckEnrollments = await canvasApi.get(
-    `courses/${ckId}/enrollments?sis_section_id[]=app.katalog3.A.section2`
+  const ckEnrollments = await canvasApi.getSectionEnrollments(
+    ckId, 'app.katalog3.A.section2'
   )
 
   t.ok(


### PR DESCRIPTION
This PR replaces `kth-canvas-api` with `@kth/canvas-api` keeping the old API in order to not break things for now

Notes:

- the project has still outdated that we might get rid of. Things like `bluebird` and `moment`.
- the project can be refactored to use `@kth/canvas-api` in a better way (specially the `pollUntilSisComplete` [function](https://github.com/KTH/lms-sync-users/compare/update-canvas-api#diff-02ad5e4c655d4fe29dff442663845319R59-R78)

This PR cannot be merged until the build server has been fixed